### PR TITLE
Update: Add npm publish to build script

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -89,6 +89,9 @@ function release(type) {
 
 	// ...and publish
 	exec('git push origin master --tags');
+
+	// also publish to npm (requires authentication)
+	exec('npm publish');
 }
 
 


### PR DESCRIPTION
Updating `npm run patch`, `npm run minor`, and `npm run major` to also publish to npm (so we don't forget).

CR @j3tan @FredKSchott @mattwiller 