### PR TITLE
Update: Throw errors on property read before write (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Fakes are objects that share a prototype chain and method definitions of another
 * You can use this object with `sinon.mock()` to set expectations that override the default method behavior of throwing an error. This ensures that only methods with expectations explicitly set can be called.
 * The fake will pass any `instanceof` checks that the original object would pass.
 
+Additionally, fakes contain all of the properties of the passed-in object. In ECMAScript 5 environments, accessing these properties without first setting them to a value will result in an errow.
+
 To create a fake, pass in the object you want to fake to `leche.fake()`, such as:
 
 ```js
@@ -84,13 +86,21 @@ Person.prototype.sayHi = function() {
 };
 
 // in a test
-var fakePerson = leche.fake(Person.prototype);
+var fakePerson = leche.fake(new Person('Jeff'));
 
 assert.ok(fakePerson instanceof Person);  // passes
 assert.ok('sayName' in fakePerson);       // passes
+assert.ok('name' in fakePerson);          // passes
 
 // throws an error
 fakePerson.sayName();
+
+// also throws an error
+var name = fakePerson.name;
+
+// won't throw an error because you've assigned a value
+fakePerson.name = 'Jeff';
+var name = fakePerson.name;
 ```
 
 Fakes are useful for creating mocks, where you set an expectation that a certain method will be called. Sinon will redefine the method with the expectation and no error will be thrown. However, trying to call any other method on the fake will result in an error. For example:
@@ -208,8 +218,6 @@ This project uses `make` for its build system, but you should use `npm` for exec
 1. Run `npm install`.
 1. Run `npm test` to ensure everything is working.
 1. Profit.
-
-
 
 ## Support
 

--- a/lib/leche.js
+++ b/lib/leche.js
@@ -28,7 +28,7 @@ require('mocha');
 /**
  * Determines if a given property is an accessor property of an object. This is
  * important because accessor properties have functions that will still execute
- * after Eos inherits from that object, effectively keeping functionality alive
+ * after Leche inherits from that object, effectively keeping functionality alive
  * on the fake object.
  * @param {Object} object The object to check.
  * @param {string} key The property name to check.
@@ -47,6 +47,40 @@ function isAccessorProperty(object, key) {
 	}
 
 	return result;
+}
+
+/**
+ * Determines if a given property is a data property in ES5. This is
+ * important because we can overwrite data properties with getters in ES5,
+ * but not in ES3.
+ * @param {Object} object The object to check.
+ * @param {string} key The property name to check.
+ * @returns {boolean} True if it's an ES5 data property, false if not.
+ * @private
+ */
+function isES5DataProperty(object, key) {
+
+	var result = false;
+
+	// make sure this works in older browsers without error
+	if (Object.getOwnPropertyDescriptor && object.hasOwnProperty(key)) {
+
+		var descriptor = Object.getOwnPropertyDescriptor(object, key);
+		result = ('value' in descriptor) && (typeof descriptor.value !== 'function');
+	}
+
+	return result;
+}
+
+/**
+ * Determines if a given property is a data property in ES3.
+ * @param {Object} object The object to check.
+ * @param {string} key The property name to check.
+ * @returns {boolean} True if it's an ES5 data property, false if not.
+ * @private
+ */
+function isES3DataProperty(object, key) {
+	return typeof object[key] !== 'function';
 }
 
 /**
@@ -106,7 +140,7 @@ function noop() {
 //------------------------------------------------------------------------------
 
 /**
- * @module eos
+ * @module leche
  */
 module.exports = {
 
@@ -161,6 +195,28 @@ module.exports = {
 					enumerable: true,
 					configurable: true
 				});
+
+			} else if (isES5DataProperty(template, key)) {
+
+				(function(propertyKey) {
+					Object.defineProperty(fake, key, {
+						get: function() {
+							throw new Error('Unexpected use of property "' + propertyKey + '".');
+						},
+						set: function(value) {
+
+							// when set, change into a data property - removes the getter and setter
+							Object.defineProperty(fake, key, { value: value });
+						},
+						enumerable: true,
+						configurable: true
+					});
+				}(key));
+
+			} else if (isES3DataProperty(template, key)) {
+
+				// can't do anything special for ES3, so just assign undefined
+				fake[key] = undefined;
 
 			} else if (typeof fake[key] === 'function') {
 				fake[key] = (function(methodKey) {

--- a/tests/lib/leche-test.js
+++ b/tests/lib/leche-test.js
@@ -102,17 +102,32 @@ describe('leche', function() {
 			}, /Unexpected call to method "method"\./);
 		});
 
-		it('should create an object whose properties remain unchanged when called on an object with only properties', function() {
+		it('should create an object whose properties throw an error when accessed', function() {
 
 			var template = {
 				name: 'leche'
 			};
 
 			var fake = leche.fake(template);
-			assert.equal(fake.name, 'leche');
+			assert.throws(function() {
+				fake.name; // calls getter
+			}, /Unexpected use of property "name"\./);
+
 		});
 
-		it('should should create an object with a data property when called on an object with only an accessor property', function() {
+		it('should create an object whose properties do not throw an error when set to a value', function() {
+
+			var template = {
+				name: 'leche'
+			};
+
+			var fake = leche.fake(template);
+			fake.name = 'box';
+
+			assert.equal(fake.name, 'box');
+		});
+
+		it('should create an object with a data property when called on an object with only an accessor property', function() {
 
 			var template = {
 				get data() {
@@ -124,6 +139,7 @@ describe('leche', function() {
 			assert.isTrue('data' in fake);
 			assert.isUndefined(fake.data);
 		});
+
 
 	});
 


### PR DESCRIPTION
This adds the behavior to throw errors when a property is accessed without first setting its value. So you can do this:

```js
var person = { name: 'Nicholas' };
var fakePerson = leche.fake(person);

var name = fakePerson.name;   // throws an error "Unexpected access of property "name"

// but if you assign it a value first, it's fine
fakePerson.name = 'Nicholas';
var name = fakePerson.name;
```

CR @j3tan @FredKSchott @mattwiller