### PR TITLE
Update peer dependencies to include mocha 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "major": "node Makefile.js major"
   },
   "peerDependencies": {
-    "mocha": ">=1.18 <3"
+    "mocha": ">=1.18 <4"
   },
   "devDependencies": {
     "browserify": "^5.11.2",
@@ -34,13 +34,12 @@
     "istanbul": "^0.3.2",
     "jsdoc": "^3.3.0-alpha9",
     "jsonlint": "^1.6.2",
-    "mocha": "^2.1.0",
-    "mocha-phantomjs": "^3.5.3",
+    "mocha": "^3.0.2",
+    "mocha-phantomjs": "^4.1.0",
     "mockery": "~1.4",
-    "phantomjs": "^1.9.15",
     "shelljs": "^0.3.0",
     "shelljs-nodecli": "^0.1.1",
-    "sinon": "^1.12.2",
+    "sinon": "1.17.5",
     "uglify-js": "^2.4.16"
   }
 }

--- a/tests/tests.htm
+++ b/tests/tests.htm
@@ -10,7 +10,7 @@
     <!-- test framework -->
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
-    <script src="../node_modules/sinon/pkg/sinon-1.12.2.js"></script>
+    <script src="../node_modules/sinon/pkg/sinon-1.17.5.js"></script>
 
     <!-- source -->
     <script src="../build/leche.js"></script>


### PR DESCRIPTION
Updating dependencies to allow use with mocha 3.x; it looks like all tests pass and I've done testing on some internal repos that use leche to ensure that it works.

Fixes #16 

@j3tan for review