### PR TITLE
Using withData, infer test names from objects

### DIFF
--- a/lib/leche.js
+++ b/lib/leche.js
@@ -98,6 +98,42 @@ function createObject(proto) {
 }
 
 /**
+ * Returns the first maxLen characters of a the JSON string representation of
+ * the given object.
+ *
+ * @param {Object} object The object to get a string representation for.
+ * @param {number} maxLen The number of characters to truncate to.
+ * @returns {string} The first maxLen characters of the JSON string.
+ */
+function truncatedJSONStringify(object, maxLen) {
+	return JSON.stringify(object).slice(0, maxLen);
+}
+
+/**
+ * Gets a string representation of an object. If there is a usable toString()
+ * implementation, then it will return that. Otherwise, it will attempt to get
+ * a more specific string representation by getting the JSON string version of
+ * the object. For arrays, it will attempt to stringify its items recursively.
+ *
+ * @param {*} object The object to get a string representation for.
+ * @param {number} maxDepth The maximum depth to recurse for arrays.
+ * @returns {string} The string representation of the object.
+ * @private
+ */
+function stringifyObject(object, maxDepth) {
+	var stringRepresentation = object.toString();
+	if (object instanceof Array && maxDepth > 0) {
+		return object.map(function(item) {
+			return stringifyObject(item, maxDepth - 1);
+		}).toString();
+	} else if (stringRepresentation === '[object Object]') {
+		return truncatedJSONStringify(object, 30);
+	} else {
+		return stringRepresentation;
+	}
+}
+
+/**
  * Converts an array into an object whose keys are a string representation of the
  * each array item and whose values are each array item. This is to normalize the
  * information into an object so that other operations can assume objects are
@@ -120,7 +156,7 @@ function createNamedDataset(array) {
 	var result = {};
 
 	for (var i = 0, len = array.length; i < len; i++) {
-		result[array[i].toString()] = array[i];
+		result[stringifyObject(array[i], 1)] = array[i];
 	}
 
 	return result;

--- a/tests/lib/leche-test.js
+++ b/tests/lib/leche-test.js
@@ -240,6 +240,21 @@ describe('leche', function() {
 			assert.ok(secondCall.calledWith(3, 4));
 		});
 
+		it ('should call the passed-in function multiple times with an array of objects', function() {
+			var spy = sandbox.spy();
+
+			withData([
+				[ {a: 1}, {b: 2} ],
+				[ {c: 3}, {d: 4} ]
+			], spy);
+
+			var firstCall = spy.getCall(0),
+				secondCall = spy.getCall(1);
+
+			assert.ok(spy.calledTwice);
+			assert.ok(firstCall.calledWith({a: 1}, {b: 2}));
+			assert.ok(secondCall.calledWith({c: 3}, {d: 4}));
+		});
 
 		it ('should call the passed-in function multiple times with an array dataset and non-array values', function() {
 			var spy = sandbox.spy();
@@ -255,6 +270,22 @@ describe('leche', function() {
 			assert.ok(spy.calledTwice);
 			assert.ok(firstCall.calledWith(1));
 			assert.ok(secondCall.calledWith(2));
+		});
+
+		it ('should call the passed-in function multiple times with an array dataset of plain object values', function() {
+			var spy = sandbox.spy();
+
+			withData([
+				{a: 1},
+				{b: 2}
+			], spy);
+
+			var firstCall = spy.getCall(0),
+				secondCall = spy.getCall(1);
+
+			assert.ok(spy.calledTwice);
+			assert.ok(firstCall.calledWith({a: 1}));
+			assert.ok(secondCall.calledWith({b: 2}));
 		});
 
 		it ('should throw an error when the first argument is null', function() {
@@ -302,6 +333,21 @@ describe('leche', function() {
 
 		});
 
+		describe('implicit test names with arrays of objects', function() {
+
+			withData([
+				[ {a: 1}, {b: 2} ],
+				[ {c: 3}, {d: 4} ]
+			], function(first, second) {
+				it('should report the test name', function() {
+
+					// checks the previous describe()'s title
+					assert.equal(this.test.parent.title, TEST_PREFIX + [JSON.stringify(first), JSON.stringify(second)]);
+				});
+			});
+
+		});
+
 		describe('implicit test names with primitives', function() {
 
 			withData([
@@ -312,6 +358,38 @@ describe('leche', function() {
 
 					// checks the previous describe()'s title
 					assert.equal(this.test.parent.title, TEST_PREFIX + expected);
+				});
+			});
+
+		});
+
+		describe('implicit test names with plain objects', function() {
+
+			withData([
+				{a: 1}
+			], function(object) {
+				it('should report the test name', function() {
+
+					// checks the previous describe()'s title
+					assert.equal(this.test.parent.title, TEST_PREFIX + JSON.stringify(object));
+				});
+			});
+
+		});
+
+		describe('implicit test names with class instances', function() {
+
+			function TestClass() {
+				this.a = 1;
+			}
+
+			withData([
+				new TestClass()
+			], function(object) {
+				it('should report the test name', function() {
+
+					// checks the previous describe()'s title
+					assert.equal(this.test.parent.title, TEST_PREFIX + JSON.stringify(object));
 				});
 			});
 


### PR DESCRIPTION
When using `withData` with an unlabeled dataset of objects or arrays of objects, previous behavior would result in only the last test case being due to a name collision: `someObject.toString()` results in `'[object Object]'`.

This implements the first potential solution mentioned in #21.